### PR TITLE
returns ArrayRef in scalar context?

### DIFF
--- a/lib/Data/Page/Navigation.pm
+++ b/lib/Data/Page/Navigation.pm
@@ -31,7 +31,7 @@ sub pages_in_navigation(){
         }
         $i++;
     }
-    return @ret;
+    return wantarray ? @ret : \@ret;
 }
 
 sub first_navigation_page {
@@ -90,7 +90,7 @@ Setting the number of page numbers displayed on one page. default is 10
 
 =head2 pages_in_navigation([pages_per_navigation])
 
-This method returns an array where page numbers of the number that you set with pages_per_navigation are included
+This method returns an array (or array-ref in scalar context) where page numbers of the number that you set with pages_per_navigation are included.
 
 =head2 first_navigation_page
 

--- a/t/02_navigation.t
+++ b/t/02_navigation.t
@@ -1,4 +1,4 @@
-use Test::More tests => 16;
+use Test::More tests => 17;
 use Data::Page::Navigation;
 
 #first
@@ -19,6 +19,8 @@ use Data::Page::Navigation;
     
     is($pager->pages_per_navigation,$pages_per_navigation,"first: object method: pages_per_navigation");
     is_deeply([$pager->pages_in_navigation],[qw/1 2 3 4 5/],"first: pages_in_navigation p2");
+    
+    is_deeply(scalar $pager->pages_in_navigation, [qw/1 2 3 4 5/],"scalar context");
     
     #first/last_naviagtion_page
     is($pager->first_navigation_page,1,"first: first_navigation_page p2");


### PR DESCRIPTION
pages_in_navigation()がスカラーコンテキストで配列リファレンスを返すようにしたらいかがでしょう。

これは現在スカラーコンテキストでpages_in_navigation()を受けることで要素数を知る、という使い方をしている場合に非互換となりますが、そういう人はいないのではないか、と思います。

なお、これはText::Xslateでpager.pages_in_navigation()という使い方をしたくて気づいただけです。Xslate側では現時点ではリストコンテキストをやる方法は今の所ないとのこと。

https://github.com/gfx/p5-Text-Xslate/issues/issue/26/#comment_752542
